### PR TITLE
updated stdlib dynamic to dynamic/decode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "26.0.2"
-          gleam-version: "1.2.0"
+          gleam-version: "1.9.0"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
       - run: gleam deps download

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,6 +1,7 @@
 name = "bravo"
 version = "0.0.0"
 target = "erlang"
+gleam = ">= 1.9.0"
 internal_modules = [
   "bravo/internal",
   "bravo/internal/*",
@@ -10,8 +11,8 @@ licences = ["Apache-2.0"]
 repository = { type = "github", user = "Michael-Mark-Edu", repo = "bravo" }
 
 [dependencies]
-gleam_stdlib = ">= 0.33.0 and < 1.0.0"
-gleam_erlang = ">= 0.23.1 and < 1.0.0"
+gleam_stdlib = ">= 0.58.0 and < 1.0.0"
+gleam_erlang = ">= 0.34.0 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,19 +2,19 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
-  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
-  { name = "shellout", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "E2FCD18957F0E9F67E1F497FC9FF57393392F8A9BAEAEA4779541DE7A68DD7E0" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
+  { name = "gleam_otp", version = "0.16.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "50DA1539FC8E8FA09924EB36A67A2BBB0AD6B27BCDED5A7EF627057CF69D035E" },
+  { name = "gleam_stdlib", version = "0.58.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "091F2D2C4A3A4E2047986C47E2C2C9D728A4E068ABB31FDA17B0D347E6248467" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
+  { name = "shellout", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "1BDC03438FEB97A6AF3E396F4ABEB32BECF20DF2452EC9A8C0ACEB7BDDF70B14" },
   { name = "simplifile", version = "1.7.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "1D5DFA3A2F9319EC85825F6ED88B8E449F381B0D55A62F5E61424E748E7DDEB0" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.23.1 and < 1.0.0" }
+gleam_erlang = { version = ">= 0.34.0 and < 1.0.0" }
 gleam_otp = { version = ">= 0.10.0 and < 1.0.0" }
-gleam_stdlib = { version = ">= 0.33.0 and < 1.0.0" }
+gleam_stdlib = { version = ">= 0.58.0 and < 1.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
-shellout = { version = ">= 1.6.0 and < 2.0.0"}
+shellout = { version = ">= 1.6.0 and < 2.0.0" }
 simplifile = { version = ">= 1.7.0 and < 2.0.0" }

--- a/src/bravo/bag.gleam
+++ b/src/bravo/bag.gleam
@@ -3,7 +3,7 @@
 import bravo.{type Access, type BravoError}
 import bravo/internal/master
 import bravo/internal/new_options
-import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode.{type Decoder}
 import gleam/result
 
 /// A bag table. Keys may occur multiple times per table, but exact key-value
@@ -360,8 +360,8 @@ pub fn tab2file(
 /// written, which may result in issues if the table was written to during the
 /// original dump; avoid this by setting `verify` to false, or setting either
 /// `tab2file`'s `object_count` or `md5sum` flags to `true`.
-/// - `k key_decoder: fn(Dynamic) -> Result(k, _),
-///   v value_decoder: fn(Dynamic) -> Result(v, _)`
+/// - `k key_decoder: Decoder(k),
+///   v value_decoder: Decoder(v)`
 /// Used to ensure at runtime that the type of the table makes sense. The types
 /// of the key and value are *not* stored in the file, so you must know what the
 /// types are supposed to be when calling this function through other means.
@@ -380,8 +380,8 @@ pub fn tab2file(
 pub fn file2tab(
   from filename: String,
   verify verify: Bool,
-  k key_decoder: fn(Dynamic) -> Result(k, _),
-  v value_decoder: fn(Dynamic) -> Result(v, _),
+  k key_decoder: Decoder(k),
+  v value_decoder: Decoder(v),
 ) -> Result(Bag(k, v), BravoError) {
   use res <- result.try(master.file2tab(
     filename,

--- a/src/bravo/dbag.gleam
+++ b/src/bravo/dbag.gleam
@@ -3,7 +3,7 @@
 import bravo.{type Access, type BravoError}
 import bravo/internal/master
 import bravo/internal/new_options
-import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode.{type Decoder}
 import gleam/result
 
 /// A duplicate bag bravo. Keys may occur multiple times per table, and verbatim
@@ -358,8 +358,8 @@ pub fn tab2file(
 /// written, which may result in issues if the table was written to during the
 /// original dump; avoid this by setting `verify` to false, or setting either
 /// `tab2file`'s `object_count` or `md5sum` flags to `true`.
-/// - `k key_decoder: fn(Dynamic) -> Result(k, _),
-///   v value_decoder: fn(Dynamic) -> Result(v, _)`
+/// - `k key_decoder: Decoder(k),
+///   v value_decoder: Decoder(v)`
 /// Used to ensure at runtime that the type of the table makes sense. The types
 /// of the key and value are *not* stored in the file, so you must know what the
 /// types are supposed to be when calling this function through other means.
@@ -378,8 +378,8 @@ pub fn tab2file(
 pub fn file2tab(
   from filename: String,
   verify verify: Bool,
-  k key_decoder: fn(Dynamic) -> Result(k, _),
-  v value_decoder: fn(Dynamic) -> Result(v, _),
+  k key_decoder: Decoder(k),
+  v value_decoder: Decoder(v),
 ) -> Result(DBag(k, v), BravoError) {
   use res <- result.try(master.file2tab(
     filename,

--- a/src/bravo/internal/master.gleam
+++ b/src/bravo/internal/master.gleam
@@ -2,7 +2,7 @@ import bravo.{type Access, type BravoError}
 import bravo/internal/bindings
 import bravo/internal/new_options
 import gleam/bool
-import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode.{type Decoder}
 import gleam/erlang.{type Reference}
 import gleam/erlang/atom.{type Atom}
 import gleam/list
@@ -151,8 +151,8 @@ pub fn tab2file(
 pub fn file2tab(
   filename: String,
   verify: Bool,
-  key_decode: fn(Dynamic) -> Result(k, _),
-  value_decode: fn(Dynamic) -> Result(v, _),
+  key_decode: Decoder(k),
+  value_decode: Decoder(v),
 ) -> Result(InnerTable, BravoError) {
   use atom <- result.try(bindings.try_file2tab(
     string.to_utf_codepoints(filename),
@@ -165,11 +165,11 @@ pub fn file2tab(
       use object <- list.all(objects)
       let key =
         object.0
-        |> key_decode
+        |> decode.run(key_decode)
         |> result.is_ok
       let value =
         object.1
-        |> value_decode
+        |> decode.run(value_decode)
         |> result.is_ok
       bool.and(key, value)
     }

--- a/src/bravo/oset.gleam
+++ b/src/bravo/oset.gleam
@@ -3,7 +3,7 @@
 import bravo.{type Access, type BravoError}
 import bravo/internal/master
 import bravo/internal/new_options
-import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode.{type Decoder}
 import gleam/result
 
 /// An ordered set. Keys may only occur once per table, and keys are ordered
@@ -363,8 +363,8 @@ pub fn tab2file(
 /// written, which may result in issues if the table was written to during the
 /// original dump; avoid this by setting `verify` to false, or setting either
 /// `tab2file`'s `object_count` or `md5sum` flags to `true`.
-/// - `k key_decoder: fn(Dynamic) -> Result(k, _),
-///   v value_decoder: fn(Dynamic) -> Result(v, _)`
+/// - `k key_decoder: Decoder(k),
+///   v value_decoder: Decoder(v)`
 /// Used to ensure at runtime that the type of the table makes sense. The types
 /// of the key and value are *not* stored in the file, so you must know what the
 /// types are supposed to be when calling this function through other means.
@@ -383,8 +383,8 @@ pub fn tab2file(
 pub fn file2tab(
   from filename: String,
   verify verify: Bool,
-  k key_decoder: fn(Dynamic) -> Result(k, _),
-  v value_decoder: fn(Dynamic) -> Result(v, _),
+  k key_decoder: Decoder(k),
+  v value_decoder: Decoder(v),
 ) -> Result(OSet(k, v), BravoError) {
   use res <- result.try(master.file2tab(
     filename,

--- a/src/bravo/uset.gleam
+++ b/src/bravo/uset.gleam
@@ -3,7 +3,7 @@
 import bravo.{type Access, type BravoError}
 import bravo/internal/master
 import bravo/internal/new_options
-import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode.{type Decoder}
 import gleam/result
 
 /// An unordered set. Keys may only occur once per table and are unordered.
@@ -355,8 +355,8 @@ pub fn tab2file(
 /// written, which may result in issues if the table was written to during the
 /// original dump; avoid this by setting `verify` to false, or setting either
 /// `tab2file`'s `object_count` or `md5sum` flags to `true`.
-/// - `k key_decoder: fn(Dynamic) -> Result(k, _),
-///   v value_decoder: fn(Dynamic) -> Result(v, _)`
+/// - `k key_decoder: Decoder(k),
+///   v value_decoder: Decoder(v)`
 /// Used to ensure at runtime that the type of the table makes sense. The types
 /// of the key and value are *not* stored in the file, so you must know what the
 /// types are supposed to be when calling this function through other means.
@@ -375,8 +375,8 @@ pub fn tab2file(
 pub fn file2tab(
   from filename: String,
   verify verify: Bool,
-  k key_decoder: fn(Dynamic) -> Result(k, _),
-  v value_decoder: fn(Dynamic) -> Result(v, _),
+  k key_decoder: Decoder(k),
+  v value_decoder: Decoder(v),
 ) -> Result(USet(k, v), BravoError) {
   use res <- result.try(master.file2tab(
     filename,

--- a/test/bag_test.gleam
+++ b/test/bag_test.gleam
@@ -1,7 +1,7 @@
 import bravo
 import bravo/bag
 import gleam/dict
-import gleam/dynamic
+import gleam/dynamic/decode
 import gleam/list
 import gleam/otp/task
 import gleeunit/should
@@ -159,16 +159,16 @@ pub fn bag_tab2file_test() {
 
 pub fn bag_file2tab_test() {
   let assert Ok(new_table) =
-    bag.file2tab("bag9", True, dynamic.string, dynamic.string)
+    bag.file2tab("bag9", True, decode.string, decode.string)
   bag.lookup(new_table, "Hello")
   |> should.equal(Ok(["World"]))
   bag.delete(new_table)
   |> should.be_ok
-  bag.file2tab("bag9", True, dynamic.int, dynamic.int)
+  bag.file2tab("bag9", True, decode.int, decode.int)
   |> should.equal(Error(bravo.DecodeFailure))
   simplifile.delete("bag9")
   |> should.be_ok
-  bag.file2tab("no_access/bag9", True, dynamic.string, dynamic.string)
+  bag.file2tab("no_access/bag9", True, decode.string, decode.string)
   |> should.equal(Error(bravo.FileDoesNotExist))
 }
 

--- a/test/dbag_test.gleam
+++ b/test/dbag_test.gleam
@@ -1,7 +1,7 @@
 import bravo
 import bravo/dbag
 import gleam/dict
-import gleam/dynamic
+import gleam/dynamic/decode
 import gleam/list
 import gleam/otp/task
 import gleeunit/should
@@ -159,16 +159,16 @@ pub fn dbag_tab2file_test() {
 
 pub fn dbag_file2tab_test() {
   let assert Ok(new_table) =
-    dbag.file2tab("dbag9", True, dynamic.string, dynamic.string)
+    dbag.file2tab("dbag9", True, decode.string, decode.string)
   dbag.lookup(new_table, "Hello")
   |> should.equal(Ok(["World"]))
   dbag.delete(new_table)
   |> should.be_ok
-  dbag.file2tab("dbag9", True, dynamic.int, dynamic.int)
+  dbag.file2tab("dbag9", True, decode.int, decode.int)
   |> should.equal(Error(bravo.DecodeFailure))
   simplifile.delete("dbag9")
   |> should.be_ok
-  dbag.file2tab("no_access/dbag9", True, dynamic.string, dynamic.string)
+  dbag.file2tab("no_access/dbag9", True, decode.string, decode.string)
   |> should.equal(Error(bravo.FileDoesNotExist))
 }
 

--- a/test/oset_test.gleam
+++ b/test/oset_test.gleam
@@ -1,7 +1,7 @@
 import bravo
 import bravo/oset
 import gleam/dict
-import gleam/dynamic
+import gleam/dynamic/decode
 import gleam/otp/task
 import gleeunit/should
 import shellout
@@ -152,16 +152,16 @@ pub fn oset_tab2file_test() {
 
 pub fn oset_file2tab_test() {
   let assert Ok(new_table) =
-    oset.file2tab("oset9", True, dynamic.string, dynamic.string)
+    oset.file2tab("oset9", True, decode.string, decode.string)
   oset.lookup(new_table, "Hello")
   |> should.equal(Ok("World"))
   oset.delete(new_table)
   |> should.be_ok
-  oset.file2tab("oset9", True, dynamic.int, dynamic.int)
+  oset.file2tab("oset9", True, decode.int, decode.int)
   |> should.equal(Error(bravo.DecodeFailure))
   simplifile.delete("oset9")
   |> should.be_ok
-  oset.file2tab("no_access/oset9", True, dynamic.string, dynamic.string)
+  oset.file2tab("no_access/oset9", True, decode.string, decode.string)
   |> should.equal(Error(bravo.FileDoesNotExist))
 }
 

--- a/test/uset_test.gleam
+++ b/test/uset_test.gleam
@@ -1,7 +1,7 @@
 import bravo
 import bravo/uset
 import gleam/dict
-import gleam/dynamic
+import gleam/dynamic/decode
 import gleam/list
 import gleam/otp/task
 import gleeunit/should
@@ -153,16 +153,16 @@ pub fn uset_tab2file_test() {
 
 pub fn uset_file2tab_test() {
   let assert Ok(new_table) =
-    uset.file2tab("uset9", True, dynamic.string, dynamic.string)
+    uset.file2tab("uset9", True, decode.string, decode.string)
   uset.lookup(new_table, "Hello")
   |> should.equal(Ok("World"))
   uset.delete(new_table)
   |> should.be_ok
-  uset.file2tab("uset9", True, dynamic.int, dynamic.int)
+  uset.file2tab("uset9", True, decode.int, decode.int)
   |> should.equal(Error(bravo.DecodeFailure))
   simplifile.delete("uset9")
   |> should.be_ok
-  uset.file2tab("no_access/uset9", True, dynamic.string, dynamic.string)
+  uset.file2tab("no_access/uset9", True, decode.string, decode.string)
   |> should.equal(Error(bravo.FileDoesNotExist))
 }
 


### PR DESCRIPTION
resolves #3

## Changes
- updated gleam_stdlib to version 0.58.0 & others
- updated gleam.toml to have required version for gleam_stdlib and gleam reflected
- updated function api to use new Decoder type

## Breaking
- gleam (>= 1.9.0)
- gleam_stdlib (>= 0.58.0)
- function signature changed on all `file2tab` functions
